### PR TITLE
Add bootstrapper CD workflow

### DIFF
--- a/.github/workflows/_release-terraform-apply-bootstrapper-prod.yaml
+++ b/.github/workflows/_release-terraform-apply-bootstrapper-prod.yaml
@@ -1,0 +1,20 @@
+name: Release Bootstrapper Infrastructure - prod
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "infra/bootstrapper/prod/**"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  release:
+    uses: pagopa/dx/.github/workflows/release-terraform-bootstrapper-v1.yaml@main
+    name: Release Bootstrapper (prod)
+    secrets: inherit
+    with:
+      environment: 'prod'

--- a/.github/workflows/_release-terraform-apply-bootstrapper-prod.yaml
+++ b/.github/workflows/_release-terraform-apply-bootstrapper-prod.yaml
@@ -17,4 +17,4 @@ jobs:
     name: Release Bootstrapper (prod)
     secrets: inherit
     with:
-      environment: 'prod'
+      environment: prod


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the release process for the production bootstrapper infrastructure. The workflow is triggered on pushes to the `main` branch that affect files in the `infra/bootstrapper/prod/` directory, or via manual dispatch.

**Infrastructure automation:**

* Added `.github/workflows/_release-terraform-apply-bootstrapper-prod.yaml` to automate the release of the production bootstrapper infrastructure using a reusable workflow, with appropriate permissions and environment targeting.