### PR TITLE
chore: update actions to their version that uses node24

### DIFF
--- a/.github/workflows/cdn_deploy.yaml
+++ b/.github/workflows/cdn_deploy.yaml
@@ -64,7 +64,7 @@ jobs:
       TURBO_CACHE_DIR: .turbo-cache
 
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         name: Checkout
 
       - name: Prune
@@ -74,7 +74,7 @@ jobs:
         run: corepack enable
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: ".node-version"
           cache: "pnpm"
@@ -86,7 +86,7 @@ jobs:
         working-directory: ./out
 
       - name: Restore turbo cache
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 #v4.2.0
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ./out/${{ env.TURBO_CACHE_DIR }}
           key: ${{ runner.os }}-turbo-${{ github.sha }}
@@ -130,12 +130,12 @@ jobs:
 
     steps:
       - name: Download Artifact
-        uses: actions/download-artifact@87c55149d96e628cc2ef7e6fc2aab372015aec85 # v4.1.3
+        uses: pagopa/dx/.github/actions/download-artifact@main
         with:
-          name: ${{ env.BUNDLE_NAME }}
+          bundle_name: ${{ env.BUNDLE_NAME }}
 
       - name: Azure Login
-        uses: azure/login@a65d910e8af852a8061c627c456678983e180302 # v2
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         env:
           ARM_USE_OIDC: true
         with:


### PR DESCRIPTION
Closes [IEG-2854](https://pagopa.atlassian.net/browse/IEG-2854)

[IEG-2854]: https://pagopa.atlassian.net/browse/IEG-2854?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ