### PR TITLE
chore: update workflow reference to main

### DIFF
--- a/.github/workflows/deploy-support-func.yaml
+++ b/.github/workflows/deploy-support-func.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   deploy:
     name: Deploy Support Func
-    uses: pagopa/dx/.github/workflows/release-azure-appsvc-v1.yaml@d187d7667ee20d93cb588e06d7ab194ece3de911
+    uses: pagopa/dx/.github/workflows/release-azure-appsvc-v1.yaml@main
     secrets: inherit
     with:
       workspace_name: support-func


### PR DESCRIPTION
It's safe to point to main and not to a commit sha, because it's an internal workflow and it's versioned (v1). In case of breaking changes, the dx team'll release a new version (ex: v2).

Closes [IEG-2855](https://pagopa.atlassian.net/browse/IEG-2855)

[IEG-2855]: https://pagopa.atlassian.net/browse/IEG-2855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ