### PR TITLE
chore: update actions to their version supporting node 24

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,7 +1,21 @@
-backend: apps/backend-func/**/*
-frontend: apps/frontend/**/*
-internal: packages/**/*
-docs: docs/**/*
-ci: .github/workflows/**/*
-infra: infra/**/*
-changeset: .changeset/**/*
+backend:
+  - changed-files:
+      - any-glob-to-any-file: apps/backend-func/**/*
+frontend:
+  - changed-files:
+      - any-glob-to-any-file: apps/frontend/**/*
+internal:
+  - changed-files:
+      - any-glob-to-any-file: packages/**/*
+docs:
+  - changed-files:
+      - any-glob-to-any-file: docs/**/*
+ci:
+  - changed-files:
+      - any-glob-to-any-file: .github/workflows/**/*
+infra:
+  - changed-files:
+      - any-glob-to-any-file: infra/**/*
+changeset:
+  - changed-files:
+      - any-glob-to-any-file: .changeset/**/*

--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -11,19 +11,19 @@ on: [pull_request]
 
 jobs:
   label:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
 
     steps:
-      - uses: actions/labeler@ba790c862c380240c6d5e7427be5ace9a05c754b #v4.0.3
+      - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
 
       # Note that the following step
       # never removes labels
-      - uses: actions/github-script@98814c53be79b1d30f795b907e553d8679345975 # v6.4.0
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         id: set-result
         with:
           script: |


### PR DESCRIPTION
Closes [IEG-2856](https://pagopa.atlassian.net/browse/IEG-2856)

[IEG-2856]: https://pagopa.atlassian.net/browse/IEG-2856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ