### PR TITLE
chore: remove `injectWorkspacePackages`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,7 +3,6 @@ lockfileVersion: '9.0'
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
-  injectWorkspacePackages: true
 
 catalogs:
   default:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,6 @@
 linkWorkspacePackages: true
 packageImportMethod: "clone-or-copy"
 cleanupUnusedCatalogs: false
-injectWorkspacePackages: true
 
 packages:
   - apps/*


### PR DESCRIPTION
## Description

This PR removes `injectWorkspacePackages: true` that breaks the codereview workflow (both in CI and locally) fi you run a `pnpm update`.

Bumping a single package manually in package file and running only `pnpm install` works fine, while running `pnpm update` (es: `pnpm update turbo -r --lockfile-only`) hard link packages driven by the `injectWorkspacePackages: true` setting in `pnpm-workspace.yaml `

https://github.com/pagopa/io-cdc/blob/086c7c77b7ac9840889af60228e8259254b433bb/pnpm-workspace.yaml#L4

The setting also conflicts with `linkWorkspacePackages` (https://pnpm.io/workspaces#linkworkspacepackages) introduced later.

Removing `injectWorkspacePackages: true` from `pnpm-workspace.yaml` makes the project more resilient to future OER PRs and avoid the `lockfile` being regenerated in the `file:packages/...` form.

## Why it was added (historical note)

The setting was introduced during the pnpm migration to work around an Azure Functions issue: the build was green, but the generated artifact (dist) did not contain all dependencies, because the Functions runtime does not resolve workspace symlinks well. The problem only surfaced after deploy.

Introducing commit (committed directly to main, no PR): 051efb41477f29a3cd23593e6e4a2661f4e7699b

## Risk and impact ⚠️

CI can be green even if the artifact is incomplete: the risk is taking CDC down after deploy, because the Functions might fail to load all dependencies.

That said, in the current pnpm lockfile all workspace packages already appear as `link:` (symlinked) rather than `file:`/hard-linked, which suggests `injectWorkspacePackages: true` is no longer actually in effect and supports its removal.

## Rollback plan (swap-back)

If the Functions fail to load correctly after deploy:

 1. Revert this PR (`restore injectWorkspacePackages: true`).
 2. Re-deploy to return to the previous state.

All the context is documented above precisely to make a potential swap-back easy.

How to test

 - [ ]  pnpm install regenerates the lockfile with packages in `link:` form (not `file:`).
 - [ ]  codereview workflow is green in CI.
 - [ ]  Functions build completes and the artifact is verified (ideally by running the dist locally).
 - [ ]  (Post-deploy) CDC Functions are up and running in the environment.
