### PR TITLE
chore: add azure login too

### DIFF
--- a/infra/repository/providers.tf
+++ b/infra/repository/providers.tf
@@ -11,6 +11,7 @@ terraform {
     storage_account_name = "iopitntfst001"
     container_name       = "terraform-state"
     key                  = "io-cdc.repository.tfstate"
+    use_azuread_auth     = true
   }
 }
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
Use `terraform import module.github_repository.github_branch.main io-cdc:main` before apply

This PR adds azure login to apply github terraform plan for the new bootstrapper module.

#### List of Changes
Add azure logoin to repository module

Fixed: https://github.com/pagopa/io-cdc/actions/runs/29567962804/job/88880213287

